### PR TITLE
Implement better config system, message filtering, emoji limiting, and unique message priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,37 @@
 A quick-and-simple application for speaking twitch chat messages via TTS
 
 # Configuration guide
+This is a simple guide for the configuration file, `TwitchChatSpeaker.settings.json`.
+## Twitch settings
 ### TwitchOAuthKey - `String`
 > The OAuth2 key to use to connect to the Twitch chat.
 ### TwitchChannelName - `String`
 > The stream channel chat to connect to for reading messages.
 ### TwitchChannelId - `String`
 > The channel ID of the streamer, used for 7TV emote grabbing.
+## General settings
+General misc settings without any category.
 ### MaxMessageLength - `Whole number`
 > The maximum length a message can be for it to be read out.
+# Emoji limiting
+Emoji limiting allows you to limit the amount of 7TV emoji spam that is read out loud.
 ### LimitEmojis - `Boolean (true/false)`
 > Whether messages should go through emoji checks before being read out.
 ### MaximumEmojiLimit - `Whole number`
 > The maximum amount of 7TV emotes that can be sent **before** we begin percentage-based calculations.
 ### EmojiPercentageLimit - `Number`
 > A number between 0 and 100. If a message has more percent of 7TV emojis than this number, the message is not selected for readout.
+## Unique message prioritisation
+Unique message priotitisation is also another tool to limit the amount of spam that is read out loud.<br>
+It will keep track of the last message it read out and attempt to ignore messages which are equal to the previous message.<br>
+This will only occur for a configurable amount of tries however before reading the duplicated message again.
 ### PrioritiseUniqueMessages - `Boolean (true/false)`
 > Whether duplicate messages will be avoided in favour of unique messages as much as possible.
 ### AttemptsBeforeFailingUnique - `Whole number`
 > How many times a duplicate message will be ignored before we give up on a unique message and say the duplicate.
+## Filter
+The filter allows you to prevent certain words from being sent, for example, a word you don't want read out or a 7TV emoji that has just too long of a name for your liking.<br>
+If a message contains a filtered word, it will not be read out and a different message will be selected to be read out instead.
 ### FilterMessages - `Boolean (true/false)`
 > Whether messages should go through filter checks before being read out.
 ### FilteredWords - `List of Strings`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # TwitchChatSpeaker
 A quick-and-simple application for speaking twitch chat messages via TTS
+
+# Configuration guide
+### TwitchOAuthKey - `String`
+> The OAuth2 key to use to connect to the Twitch chat.
+### TwitchChannelName - `String`
+> The stream channel chat to connect to for reading messages.
+### TwitchChannelId - `String`
+> The channel ID of the streamer, used for 7TV emote grabbing.
+### MaxMessageLength - `Whole number`
+> The maximum length a message can be for it to be read out.
+### LimitEmojis - `Boolean (true/false)`
+> Whether messages should go through emoji checks before being read out.
+### MaximumEmojiLimit - `Whole number`
+> The maximum amount of 7TV emotes that can be sent **before** we begin percentage-based calculations.
+### EmojiPercentageLimit - `Number`
+> A number between 0 and 100. If a message has more percent of 7TV emojis than this number, the message is not selected for readout.
+### PrioritiseUniqueMessages - `Boolean (true/false)`
+> Whether duplicate messages will be avoided in favour of unique messages as much as possible.
+### AttemptsBeforeFailingUnique - `Whole number`
+> How many times a duplicate message will be ignored before we give up on a unique message and say the duplicate.
+### FilterMessages - `Boolean (true/false)`
+> Whether messages should go through filter checks before being read out.
+### FilteredWords - `List of Strings`
+> A list of words that, if present in a message, will not be selected for readout.

--- a/TwitchChatSpeaker/EmojiCheckResult.cs
+++ b/TwitchChatSpeaker/EmojiCheckResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchChatSpeaker
+{
+    /// <summary>
+    /// Aggregate class containing results from an <see cref="Moderation.EmojiCheck(string, Settings.UserSettings, Emojis.EmojiManager)"/> call
+    /// </summary>
+    public class EmojiCheckResult
+    {
+        public bool ContainsTooManyEmotes { get; private set; }
+        public int TotalEmotesInMessage { get; private set; }
+        public double? EmotePercentage { get; private set; }
+
+        public EmojiCheckResult(bool containsTooManyEmotes, int totalEmotesInMessage, double? emotePercentage)
+        {
+            ContainsTooManyEmotes = containsTooManyEmotes;
+            TotalEmotesInMessage = totalEmotesInMessage;
+            EmotePercentage = emotePercentage;
+        }
+    }
+}

--- a/TwitchChatSpeaker/Emojis/EmojiManager.cs
+++ b/TwitchChatSpeaker/Emojis/EmojiManager.cs
@@ -1,0 +1,79 @@
+﻿using Logging;
+using Logging.API;
+using Newtonsoft.Json;
+using TwitchChatSpeaker.Emojis.types;
+using TwitchChatSpeaker.Emojis.utils;
+
+namespace TwitchChatSpeaker.Emojis;
+
+public class EmojiManager
+{
+    public List<SevenTVEmote> emotes = new List<SevenTVEmote>();
+    public string ChannelId;
+    private static readonly HttpClient client = new HttpClient();
+    
+    public EmojiManager(string channelId)
+    {
+        ChannelId = channelId;
+
+        var globalEmoteResponseString = client.GetStringAsync(Constants.SevenTVGlobal).GetAwaiter().GetResult();
+        var channelEmoteResponseString = client.GetStringAsync($"{Constants.SevenTVChannel}{ChannelId}").GetAwaiter().GetResult();
+        
+        var globalEmoteSet = JsonConvert.DeserializeObject<SevenTVEmoteSet>(globalEmoteResponseString);
+        var channelUser = JsonConvert.DeserializeObject<SevenTVUser>(channelEmoteResponseString);
+        
+        emotes.AddRange(globalEmoteSet!.emotes);
+        emotes.AddRange(channelUser!.emote_set.emotes);
+    }
+
+    public bool IsEmote(string potentialEmote)
+    {
+        var isEmote = false;
+        foreach (var emote in emotes)
+        {
+            if (isEmote) continue;
+            if (emote.name == potentialEmote) isEmote = true;
+        }
+
+        return isEmote;
+    }
+
+    public SevenTVEmote? GetEmote(string potentialEmote)
+    {
+        SevenTVEmote? isEmote = null;
+        foreach (var emote in emotes)
+        {
+            if (isEmote != null) continue;
+            if (emote.name == potentialEmote) isEmote = emote;
+        }
+
+        return isEmote;
+    }
+
+    public int GetEmoteCount(string str)
+    {
+        var splitStr = str.Split(" ");
+        var count = 0;
+
+        foreach (var word in splitStr)
+        {
+            if (IsEmote(word)) count++;
+        }
+
+        return count;
+    }
+
+    public double GetTotalEmoteNameCount(string str)
+    {
+        var splitStr = str.Split(" ");
+        var count = 0;
+
+        foreach (var word in splitStr)
+        {
+            var potentialEmote = GetEmote(word);
+            if (potentialEmote != null) count = count + potentialEmote.name.Length;
+        }
+
+        return count;
+    }
+}

--- a/TwitchChatSpeaker/Emojis/EmojiManager.cs
+++ b/TwitchChatSpeaker/Emojis/EmojiManager.cs
@@ -3,75 +3,142 @@ using Logging.API;
 using Newtonsoft.Json;
 using TwitchChatSpeaker.Emojis.types;
 using TwitchChatSpeaker.Emojis.utils;
+using TwitchLib.Client.Models;
 
 namespace TwitchChatSpeaker.Emojis;
 
+/// <summary>
+/// Responsible for managing the detection and assertion of emotes within given strings
+/// </summary>
 public class EmojiManager
 {
-    public List<SevenTVEmote> emotes = new List<SevenTVEmote>();
-    public string ChannelId;
-    private static readonly HttpClient client = new HttpClient();
+    private readonly HttpClient client = new HttpClient();
+    private readonly string channelId;
+    private readonly List<SevenTVEmote> emotes;
     
+    /// <summary>
+    /// Ctor for creating an <see cref="EmojiManager"/>
+    /// </summary>
+    /// <param name="channelId">The ID of the channel to query 7TV for to access emote sets. Cannot be null.</param>
     public EmojiManager(string channelId)
     {
-        ChannelId = channelId;
+        this.channelId = channelId ?? throw new ArgumentNullException(nameof(channelId));
+        emotes = new List<SevenTVEmote>();
+        client = new HttpClient();
 
         var globalEmoteResponseString = client.GetStringAsync(Constants.SevenTVGlobal).GetAwaiter().GetResult();
-        var channelEmoteResponseString = client.GetStringAsync($"{Constants.SevenTVChannel}{ChannelId}").GetAwaiter().GetResult();
+        var channelEmoteResponseString = client.GetStringAsync($"{Constants.SevenTVChannel}{this.channelId}").GetAwaiter().GetResult();
         
         var globalEmoteSet = JsonConvert.DeserializeObject<SevenTVEmoteSet>(globalEmoteResponseString);
         var channelUser = JsonConvert.DeserializeObject<SevenTVUser>(channelEmoteResponseString);
         
-        emotes.AddRange(globalEmoteSet!.emotes);
-        emotes.AddRange(channelUser!.emote_set.emotes);
+        emotes.AddRange(globalEmoteSet!.Emotes);
+        emotes.AddRange(channelUser!.EmoteSet.Emotes);
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> if the provided string is an emote, and <see langword="false"/> if not
+    /// </summary>
+    /// <param name="potentialEmote">The string to determine if it's an emote or not</param>
+    /// <returns><see langword="true"/> if the provided string is an emote, and <see langword="false"/> if not</returns>
     public bool IsEmote(string potentialEmote)
     {
+        if (string.IsNullOrWhiteSpace(potentialEmote))
+        {
+            return false;
+        }
+
         var isEmote = false;
         foreach (var emote in emotes)
         {
-            if (isEmote) continue;
-            if (emote.name == potentialEmote) isEmote = true;
+            if (isEmote)
+            {
+                continue;
+            }
+            if (emote.Name == potentialEmote)
+            {
+                isEmote = true;
+            }
         }
 
         return isEmote;
     }
 
+    /// <summary>
+    /// Gets the <see cref="SevenTVEmote"/> for the provided string if one exists
+    /// </summary>
+    /// <param name="potentialEmote">The string to determine if it's an emote or not</param>
+    /// <returns>The <see cref="SevenTVEmote"/> of the string if found, <see langword="null"/> if none is found</returns>
     public SevenTVEmote? GetEmote(string potentialEmote)
     {
         SevenTVEmote? isEmote = null;
+        if (string.IsNullOrWhiteSpace(potentialEmote))
+        {
+            return isEmote;
+        }
+
         foreach (var emote in emotes)
         {
-            if (isEmote != null) continue;
-            if (emote.name == potentialEmote) isEmote = emote;
+            if (isEmote != null)
+            {
+                continue;
+            }
+            if (emote.Name == potentialEmote)
+            {
+                isEmote = emote;
+            }
         }
 
         return isEmote;
     }
 
+    /// <summary>
+    /// Gets the number of emotes present in a provided string
+    /// </summary>
+    /// <param name="str">The string to determine if it's an emote or not. Checks each word within the string</param>
+    /// <returns>The number of emotes found within the string</returns>
     public int GetEmoteCount(string str)
     {
-        var splitStr = str.Split(" ");
         var count = 0;
+        if (string.IsNullOrWhiteSpace(str))
+        {
+            return count;
+        }
+
+        var splitStr = str.Split(" ");
 
         foreach (var word in splitStr)
         {
-            if (IsEmote(word)) count++;
+            if (IsEmote(word))
+            {
+                count++;
+            }
         }
 
         return count;
     }
 
+    /// <summary>
+    /// Gets the total length of all emote names within the provided string
+    /// </summary>
+    /// <param name="str">The string to determine if it's an emote or not. Checks each word within the string</param>
+    /// <returns>The total length of all emote names within the provided string</returns>
     public double GetTotalEmoteNameCount(string str)
     {
-        var splitStr = str.Split(" ");
         var count = 0;
+        if (string.IsNullOrWhiteSpace(str))
+        {
+            return count;
+        }
+        var splitStr = str.Split(" ");
 
         foreach (var word in splitStr)
         {
             var potentialEmote = GetEmote(word);
-            if (potentialEmote != null) count = count + potentialEmote.name.Length;
+            if (potentialEmote != null)
+            {
+                count += potentialEmote.Name.Length;
+            }
         }
 
         return count;

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmote.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmote.cs
@@ -1,117 +1,32 @@
-﻿namespace TwitchChatSpeaker.Emojis.types;
+﻿using Newtonsoft.Json;
 
-public class SevenTVUser
-{
-    public string display_name;
-    public int emote_capacity;
-    public SevenTVEmoteSet emote_set;
-    public string id;
-    public string platform;
-    public string username;
+namespace TwitchChatSpeaker.Emojis.types;
 
-    public SevenTVUser()
-    {
-        display_name = "";
-        emote_capacity = 1000;
-        emote_set = new SevenTVEmoteSet();
-        id = "";
-        platform = "";
-        username = "";
-    }
-}
-
-public class SevenTVEmoteSet
-{
-    public int capacity;
-    public int emote_count;
-    public List<SevenTVEmote> emotes;
-    public int flags;
-    public string id;
-    public bool immutable;
-    public string name;
-    public bool priviliged;
-
-    public SevenTVEmoteSet()
-    {
-        capacity = 0;
-        emote_count = 0;
-        emotes = new List<SevenTVEmote>();
-        flags = 0;
-        id = "";
-        immutable = true;
-        name = "";
-        priviliged = false;
-    }
-}
-
+/// <summary>
+/// Aggregate class mapping to the Emote payload from 7TV's API
+/// </summary>
 public class SevenTVEmote
 {
-    public SevenTVEmoteData data;
-    public int flags;
-    public string id;
-    public string name;
+    [JsonProperty("data")]
+    public SevenTVEmoteData Data { get; set; }
 
+    [JsonProperty("flags")]
+    public int Flags { get; set; }
+
+    [JsonProperty("id")]
+    public string ID { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a <see cref="SevenTVEmote"/>
+    /// </summary>
     public SevenTVEmote()
     {
-        data = new SevenTVEmoteData();
-        flags = 0;
-        id = "";
-        name = "";
-    }
-}
-
-public class SevenTVEmoteData
-{
-    public bool animated;
-    public int flags;
-    public SevenTVEmoteDataHost host;
-    public string id;
-    public int lifecycle;
-    public bool listed;
-    public string name;
-
-    public SevenTVEmoteData()
-    {
-        animated = false;
-        flags = 0;
-        host = new SevenTVEmoteDataHost();
-        id = "";
-        lifecycle = 3;
-        listed = false;
-        name = "";
-    }
-}
-
-public class SevenTVEmoteDataHost
-{
-    public List<SevenTVEmoteDataHostFile> files;
-    public string url;
-
-    public SevenTVEmoteDataHost()
-    {
-        files = new List<SevenTVEmoteDataHostFile>();
-        url = "";
-    }
-}
-
-public class SevenTVEmoteDataHostFile
-{
-    public string format;
-    public int frame_count;
-    public int height;
-    public int width;
-    public string name;
-    public int size;
-    public string static_name;
-
-    public SevenTVEmoteDataHostFile()
-    {
-        format = "";
-        frame_count = 1;
-        height = 0;
-        width = 0;
-        name = "";
-        size = 0;
-        static_name = "";
+        Data = new SevenTVEmoteData();
+        Flags = 0;
+        ID = "";
+        Name = "";
     }
 }

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmote.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmote.cs
@@ -1,0 +1,117 @@
+﻿namespace TwitchChatSpeaker.Emojis.types;
+
+public class SevenTVUser
+{
+    public string display_name;
+    public int emote_capacity;
+    public SevenTVEmoteSet emote_set;
+    public string id;
+    public string platform;
+    public string username;
+
+    public SevenTVUser()
+    {
+        display_name = "";
+        emote_capacity = 1000;
+        emote_set = new SevenTVEmoteSet();
+        id = "";
+        platform = "";
+        username = "";
+    }
+}
+
+public class SevenTVEmoteSet
+{
+    public int capacity;
+    public int emote_count;
+    public List<SevenTVEmote> emotes;
+    public int flags;
+    public string id;
+    public bool immutable;
+    public string name;
+    public bool priviliged;
+
+    public SevenTVEmoteSet()
+    {
+        capacity = 0;
+        emote_count = 0;
+        emotes = new List<SevenTVEmote>();
+        flags = 0;
+        id = "";
+        immutable = true;
+        name = "";
+        priviliged = false;
+    }
+}
+
+public class SevenTVEmote
+{
+    public SevenTVEmoteData data;
+    public int flags;
+    public string id;
+    public string name;
+
+    public SevenTVEmote()
+    {
+        data = new SevenTVEmoteData();
+        flags = 0;
+        id = "";
+        name = "";
+    }
+}
+
+public class SevenTVEmoteData
+{
+    public bool animated;
+    public int flags;
+    public SevenTVEmoteDataHost host;
+    public string id;
+    public int lifecycle;
+    public bool listed;
+    public string name;
+
+    public SevenTVEmoteData()
+    {
+        animated = false;
+        flags = 0;
+        host = new SevenTVEmoteDataHost();
+        id = "";
+        lifecycle = 3;
+        listed = false;
+        name = "";
+    }
+}
+
+public class SevenTVEmoteDataHost
+{
+    public List<SevenTVEmoteDataHostFile> files;
+    public string url;
+
+    public SevenTVEmoteDataHost()
+    {
+        files = new List<SevenTVEmoteDataHostFile>();
+        url = "";
+    }
+}
+
+public class SevenTVEmoteDataHostFile
+{
+    public string format;
+    public int frame_count;
+    public int height;
+    public int width;
+    public string name;
+    public int size;
+    public string static_name;
+
+    public SevenTVEmoteDataHostFile()
+    {
+        format = "";
+        frame_count = 1;
+        height = 0;
+        width = 0;
+        name = "";
+        size = 0;
+        static_name = "";
+    }
+}

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmoteData.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmoteData.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchChatSpeaker.Emojis.types;
+
+/// <summary>
+/// Aggregate class mapping to Emote Data from 7TV's API
+/// </summary>
+public class SevenTVEmoteData
+{
+    [JsonProperty("animated")]
+    public bool Animated { get; set; }
+
+    [JsonProperty("flags")]
+    public int Flags { get; set; }
+
+    [JsonProperty("host")]
+    public SevenTVEmoteDataHost Host { get; set; }
+
+    [JsonProperty("id")]
+    public string ID { get; set; }
+
+    [JsonProperty("lifecycle")]
+    public int Lifecycle { get; set; }
+
+    [JsonProperty("listed")]
+    public bool Listed { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a new <see cref="SevenTVEmoteData"/>
+    /// </summary>
+    public SevenTVEmoteData()
+    {
+        Animated = false;
+        Flags = 0;
+        Host = new SevenTVEmoteDataHost();
+        ID = "";
+        Lifecycle = 3;
+        Listed = false;
+        Name = "";
+    }
+}
+

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmoteDataHost.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmoteDataHost.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchChatSpeaker.Emojis.types;
+
+/// <summary>
+/// Aggregate class mapping to the Emote Data Host payload from 7TV's API
+/// </summary>
+public class SevenTVEmoteDataHost
+{
+    [JsonProperty("files")]
+    public List<SevenTVEmoteDataHostFile> Files { get; set; }
+
+    [JsonProperty("url")]
+    public string URL { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a <see cref="SevenTVEmoteDataHost"/>
+    /// </summary>
+    public SevenTVEmoteDataHost()
+    {
+        Files = new List<SevenTVEmoteDataHostFile>();
+        URL = "";
+    }
+}
+

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmoteDataHostFile.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmoteDataHostFile.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchChatSpeaker.Emojis.types;
+
+/// <summary>
+/// Aggregate class mapping to the Emote Data Host File Payload from 7TV's API
+/// </summary>
+public class SevenTVEmoteDataHostFile
+{
+    [JsonProperty("format")]
+    public string Format { get; set; }
+
+    [JsonProperty("frame_count")]
+    public int FrameCount { get; set; }
+
+    [JsonProperty("height")]
+    public int Height { get; set; }
+
+    [JsonProperty("width")]
+    public int Width { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("size")]
+    public int Size { get; set; }
+
+    [JsonProperty("static_name")]
+    public string StaticName { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a <see cref="SevenTVEmoteDataHostFile"/>
+    /// </summary>
+    public SevenTVEmoteDataHostFile()
+    {
+        Format = "";
+        FrameCount = 1;
+        Height = 0;
+        Width = 0;
+        Name = "";
+        Size = 0;
+        StaticName = "";
+    }
+}
+

--- a/TwitchChatSpeaker/Emojis/types/SevenTVEmoteSet.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVEmoteSet.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchChatSpeaker.Emojis.types;
+
+/// <summary>
+/// Aggregate class mapping to the Emote Set payload from 7TV's API
+/// </summary>
+public class SevenTVEmoteSet
+{
+    [JsonProperty("capacity")]
+    public int Capacity { get; set; }
+
+    [JsonProperty("emote_count")]
+    public int EmoteCount { get; set; }
+
+    [JsonProperty("emotes")]
+    public List<SevenTVEmote> Emotes { get; set; }
+
+    [JsonProperty("flags")]
+    public int Flags { get; set; }
+
+    [JsonProperty("id")]
+    public string ID { get; set; }
+
+    [JsonProperty("immutable")]
+    public bool Immutable { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("priviliged")]
+    public bool Priviliged { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a <see cref="SevenTVEmoteSet"/>
+    /// </summary>
+    public SevenTVEmoteSet()
+    {
+        Capacity = 0;
+        EmoteCount = 0;
+        Emotes = new List<SevenTVEmote>();
+        Flags = 0;
+        ID = "";
+        Immutable = true;
+        Name = "";
+        Priviliged = false;
+    }
+}
+

--- a/TwitchChatSpeaker/Emojis/types/SevenTVUser.cs
+++ b/TwitchChatSpeaker/Emojis/types/SevenTVUser.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+
+namespace TwitchChatSpeaker.Emojis.types;
+
+/// <summary>
+/// Aggregate class mapping to the User payload from 7TV's API
+/// </summary>
+public class SevenTVUser
+{
+    [JsonProperty("display_name")]
+    public string DisplayName { get; set; }
+
+    [JsonProperty("emote_capacity")]
+    public int EmoteCapacity { get; set; }
+
+    [JsonProperty("emote_set")]
+    public SevenTVEmoteSet EmoteSet { get; set; }
+
+    [JsonProperty("id")]
+    public string ID { get; set; }
+
+    [JsonProperty("platform")]
+    public string Platform { get; set; }
+
+    [JsonProperty("username")]
+    public string Username { get; set; }
+
+    /// <summary>
+    /// Default ctor for creating a <see cref="SevenTVUser"/>
+    /// </summary>
+    public SevenTVUser()
+    {
+        DisplayName = "";
+        EmoteCapacity = 1000;
+        EmoteSet = new SevenTVEmoteSet();
+        ID = "";
+        Platform = "";
+        Username = "";
+    }
+}
+

--- a/TwitchChatSpeaker/Emojis/utils/Constants.cs
+++ b/TwitchChatSpeaker/Emojis/utils/Constants.cs
@@ -1,7 +1,10 @@
 ﻿namespace TwitchChatSpeaker.Emojis.utils;
 
-public static class Constants
+/// <summary>
+/// Collection of constants for accessing the 7TV API
+/// </summary>
+public abstract class Constants
 {
-    public static string SevenTVGlobal = "https://7tv.io/v3/emote-sets/global";
-    public static string SevenTVChannel = "https://7tv.io/v3/users/twitch/";
+    public const string SevenTVGlobal = @"https://7tv.io/v3/emote-sets/global";
+    public const string SevenTVChannel = @"https://7tv.io/v3/users/twitch/";
 }

--- a/TwitchChatSpeaker/Emojis/utils/Constants.cs
+++ b/TwitchChatSpeaker/Emojis/utils/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace TwitchChatSpeaker.Emojis.utils;
+
+public static class Constants
+{
+    public static string SevenTVGlobal = "https://7tv.io/v3/emote-sets/global";
+    public static string SevenTVChannel = "https://7tv.io/v3/users/twitch/";
+}

--- a/TwitchChatSpeaker/Helpers/FileHelper.cs
+++ b/TwitchChatSpeaker/Helpers/FileHelper.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Settings;
+
+namespace TwitchChatSpeaker.Helpers;
+
+public static class FileHelper
+{
+    public static async Task<UserSettings> LoadSettingsAsync()
+    {
+        var settings = new UserSettings(); // Sets the default configuration values for now.
+
+        if (!File.Exists(TwitchSettingsContext.SettingsFileName))
+        {
+            // Convert default UserSettings into JSON using JsonConvert and save file.
+            var defaultFileContents = JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"); // Normalise some stuff
+            await File.WriteAllTextAsync(TwitchSettingsContext.SettingsFileName, defaultFileContents);
+        }
+        else
+        {
+            // File found, read and deseralize into a UserSettings which we store as settings.
+
+            var fileContents = await File.ReadAllTextAsync(TwitchSettingsContext.SettingsFileName);
+            settings = JsonConvert.DeserializeObject<UserSettings>(fileContents);
+            if (settings == null)
+                throw new InvalidDataException($"Failed to deserialize settings at {TwitchSettingsContext.SettingsFileName}");
+        }
+
+        return settings;
+    }
+
+    public static async Task SaveSettingsAsync(UserSettings settings)
+    {
+        var fileContents = JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"); // Normalise some stuff
+        await File.WriteAllTextAsync(TwitchSettingsContext.SettingsFileName, fileContents);
+    }
+}

--- a/TwitchChatSpeaker/Helpers/FileHelper.cs
+++ b/TwitchChatSpeaker/Helpers/FileHelper.cs
@@ -1,28 +1,45 @@
-﻿using Newtonsoft.Json;
+﻿using Logging;
+using Logging.API;
+using Newtonsoft.Json;
 using Settings;
 
 namespace TwitchChatSpeaker.Helpers;
 
 public static class FileHelper
 {
+    public static string GetFilePath(string name, string ext)
+    {
+        return $"{Directory.GetCurrentDirectory()}\\{name}.{ext}";
+    }
+
+    public static string GetFilePath(string file)
+    {
+        return $"{Directory.GetCurrentDirectory()}\\{file}";
+    }
+    
     public static async Task<UserSettings> LoadSettingsAsync()
     {
         var settings = new UserSettings(); // Sets the default configuration values for now.
+    
+        ILogger logger = new ConsoleLogger();
+        logger.Information(GetFilePath(TwitchSettingsContext.SettingsFileName));
 
-        if (!File.Exists(TwitchSettingsContext.SettingsFileName))
+        if (!File.Exists(GetFilePath(TwitchSettingsContext.SettingsFileName)))
         {
             // Convert default UserSettings into JSON using JsonConvert and save file.
+            logger.Information("Couldn't find config file.");
             var defaultFileContents = JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"); // Normalise some stuff
-            await File.WriteAllTextAsync(TwitchSettingsContext.SettingsFileName, defaultFileContents);
+            await File.WriteAllTextAsync(GetFilePath(TwitchSettingsContext.SettingsFileName), defaultFileContents);
         }
         else
         {
             // File found, read and deseralize into a UserSettings which we store as settings.
-
-            var fileContents = await File.ReadAllTextAsync(TwitchSettingsContext.SettingsFileName);
+            logger.Information("Found config");
+            var fileContents = await File.ReadAllTextAsync(GetFilePath(TwitchSettingsContext.SettingsFileName));
             settings = JsonConvert.DeserializeObject<UserSettings>(fileContents);
+            logger.Information(JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"));
             if (settings == null)
-                throw new InvalidDataException($"Failed to deserialize settings at {TwitchSettingsContext.SettingsFileName}");
+                throw new InvalidDataException($"Failed to deserialize settings at {GetFilePath(TwitchSettingsContext.SettingsFileName)}");
         }
 
         return settings;
@@ -31,6 +48,6 @@ public static class FileHelper
     public static async Task SaveSettingsAsync(UserSettings settings)
     {
         var fileContents = JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"); // Normalise some stuff
-        await File.WriteAllTextAsync(TwitchSettingsContext.SettingsFileName, fileContents);
+        await File.WriteAllTextAsync(GetFilePath(TwitchSettingsContext.SettingsFileName), fileContents);
     }
 }

--- a/TwitchChatSpeaker/Helpers/FileHelper.cs
+++ b/TwitchChatSpeaker/Helpers/FileHelper.cs
@@ -39,7 +39,9 @@ public static class FileHelper
             settings = JsonConvert.DeserializeObject<UserSettings>(fileContents);
             logger.Information(JsonConvert.SerializeObject(settings, Formatting.Indented).Replace("\r\n", "\n"));
             if (settings == null)
+            {
                 throw new InvalidDataException($"Failed to deserialize settings at {GetFilePath(TwitchSettingsContext.SettingsFileName)}");
+            }
         }
 
         return settings;

--- a/TwitchChatSpeaker/Moderation.cs
+++ b/TwitchChatSpeaker/Moderation.cs
@@ -12,19 +12,28 @@ public static class Moderation
         var trip = false;
         foreach (var word in settings.FilteredWords)
         {
-            if (trip) continue;
-            if (message.ToLower().Contains(word.ToLower())) trip = true;
+            if (trip)
+            {
+                continue;
+            }
+            if (message.ToLower().Contains(word.ToLower()))
+            {
+                trip = true;
+            }
         }
 
         return trip;
     }
 
-    public static (bool, int, double?) EmojiCheck(string message, UserSettings settings, EmojiManager emojiManager)
+    public static EmojiCheckResult EmojiCheck(string message, UserSettings settings, EmojiManager emojiManager)
     {
         ILogger logger = new ConsoleLogger();
         
         var totalEmoteCount = emojiManager.GetEmoteCount(message);
-        if (totalEmoteCount <= settings.MaximumEmojiLimit) return (false, totalEmoteCount, null);
+        if (totalEmoteCount <= settings.MaximumEmojiLimit)
+        {
+            return new EmojiCheckResult(false, totalEmoteCount, null);
+        }
         
         var totalEmoteNameCount = emojiManager.GetTotalEmoteNameCount(message);
         var totalMessageCount = Double.Parse(message.Length.ToString());
@@ -36,8 +45,11 @@ public static class Moderation
         
         logger.Information(percentageOfEmotesToFullMessage.ToString());
 
-        if (percentageOfEmotesToFullMessage > settings.EmojiPercentageLimit) return (true, totalEmoteCount, percentageOfEmotesToFullMessage);
+        if (percentageOfEmotesToFullMessage > settings.EmojiPercentageLimit)
+        {
+            return new EmojiCheckResult(true, totalEmoteCount, percentageOfEmotesToFullMessage);
+        }
         
-        return (false, totalEmoteCount, percentageOfEmotesToFullMessage);
+        return new EmojiCheckResult(false, totalEmoteCount, percentageOfEmotesToFullMessage);
     }
 }

--- a/TwitchChatSpeaker/Moderation.cs
+++ b/TwitchChatSpeaker/Moderation.cs
@@ -1,0 +1,43 @@
+﻿using Logging;
+using Logging.API;
+using Settings;
+using TwitchChatSpeaker.Emojis;
+
+namespace TwitchChatSpeaker;
+
+public static class Moderation
+{
+    public static bool FilterCheck(string message, UserSettings settings)
+    {
+        var trip = false;
+        foreach (var word in settings.FilteredWords)
+        {
+            if (trip) continue;
+            if (message.ToLower().Contains(word.ToLower())) trip = true;
+        }
+
+        return trip;
+    }
+
+    public static (bool, int, double?) EmojiCheck(string message, UserSettings settings, EmojiManager emojiManager)
+    {
+        ILogger logger = new ConsoleLogger();
+        
+        var totalEmoteCount = emojiManager.GetEmoteCount(message);
+        if (totalEmoteCount <= settings.MaximumEmojiLimit) return (false, totalEmoteCount, null);
+        
+        var totalEmoteNameCount = emojiManager.GetTotalEmoteNameCount(message);
+        var totalMessageCount = Double.Parse(message.Length.ToString());
+        
+        logger.Information(totalEmoteNameCount.ToString());
+        logger.Information(totalMessageCount.ToString());
+
+        var percentageOfEmotesToFullMessage = (totalEmoteNameCount / totalMessageCount) * 100;
+        
+        logger.Information(percentageOfEmotesToFullMessage.ToString());
+
+        if (percentageOfEmotesToFullMessage > settings.EmojiPercentageLimit) return (true, totalEmoteCount, percentageOfEmotesToFullMessage);
+        
+        return (false, totalEmoteCount, percentageOfEmotesToFullMessage);
+    }
+}

--- a/TwitchChatSpeaker/Program.cs
+++ b/TwitchChatSpeaker/Program.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using Settings;
 using Logging;
 using Logging.API;
+using TwitchChatSpeaker.Helpers;
 
 namespace TwitchChatSpeaker
 {
@@ -48,15 +49,15 @@ namespace TwitchChatSpeaker
             logger.Information($"Will speak chat messages in one of '{installedVoices.Count}' installed voices");
 
             // Get the user settings
-            UserSettings userSettings = new UserSettings(TwitchSettingsContext.SettingsFileName, TwitchSettingsContext.GetDefaultSettings(), logger);
-
+            var userSettings = FileHelper.LoadSettingsAsync().GetAwaiter().GetResult(); // Bypass for no async here.
+            
             // Seems to be required to save the TwitchLib dying sometimes
             System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
             // Initialise the settings and attempt to load the OAuth Token
-            string oAuthToken = userSettings.GetSettingOrDefault(TwitchSettingsContext.TwitchOAuthKey, string.Empty);
-            string twitchName = userSettings.GetSettingOrDefault(TwitchSettingsContext.TwitchChannelName, string.Empty);
-
+            var oAuthToken = userSettings.TwitchOAuthKey;
+            var twitchName = userSettings.TwitchChannelName;
+            
             // If the Oauth Token is bad, exit now
             if (string.IsNullOrWhiteSpace(oAuthToken))
             {

--- a/TwitchChatSpeaker/Program.cs
+++ b/TwitchChatSpeaker/Program.cs
@@ -170,28 +170,20 @@ namespace TwitchChatSpeaker
             }
 
             // Moderation checks
-            if (UserSettings.FilterMessages && Moderation.FilterCheck(rawMessage, UserSettings)) return;
-            var (tooManyEmotes, totalEmoteCount, emotePercentage) = Moderation.EmojiCheck(rawMessage, UserSettings, EmoteManager);
-            if (UserSettings.LimitEmojis && tooManyEmotes) return;
+            if (UserSettings.FilterMessages && Moderation.FilterCheck(rawMessage, UserSettings))
+            {
+                return;
+            }
+            EmojiCheckResult result = Moderation.EmojiCheck(rawMessage, UserSettings, EmoteManager);
+            if (UserSettings.LimitEmojis && result.ContainsTooManyEmotes)
+            {
+                return;
+            }
 
             // We reset it here because then it's either unique or repeated but it's going through!
             UniqueAttemptCount = 0;
             
-            MessagesToReadOut.Add(new TTSMessage(rawMessage, totalEmoteCount, emotePercentage));
-        }
-    }
-
-    public class TTSMessage
-    {
-        public string Message;
-        public int EmojiCount;
-        public double? PercentageOfEmotes;
-
-        public TTSMessage(string message, int emojiCount, double? perEmojiCount)
-        {
-            Message = message;
-            EmojiCount = emojiCount;
-            PercentageOfEmotes = perEmojiCount;
+            MessagesToReadOut.Add(new TTSMessage(rawMessage, result.TotalEmotesInMessage, result.EmotePercentage));
         }
     }
 }

--- a/TwitchChatSpeaker/Settings/Constants.cs
+++ b/TwitchChatSpeaker/Settings/Constants.cs
@@ -6,7 +6,10 @@ using System.Threading.Tasks;
 
 namespace Settings
 {
-    public abstract class TwitchSettingsContext
+    /// <summary>
+    /// Collection of constants for accessing the settings files
+    /// </summary>
+    public abstract class Constants
     {
         public const string SettingsFileName = "TwitchChatSpeaker.settings.json";
     }

--- a/TwitchChatSpeaker/Settings/TwitchSettingsContext.cs
+++ b/TwitchChatSpeaker/Settings/TwitchSettingsContext.cs
@@ -9,16 +9,5 @@ namespace Settings
     public abstract class TwitchSettingsContext
     {
         public const string SettingsFileName = "TwitchChatSpeaker.settings";
-        public const string TwitchOAuthKey = "TwitchOAuth";
-        public const string TwitchChannelName = "TwitchChannelName";
-
-        public static Dictionary<string, string> GetDefaultSettings()
-        {
-            return new Dictionary<string, string>()
-            {
-                { TwitchOAuthKey, "" },
-                { TwitchChannelName, "" }
-            };
-        }
     }
 }

--- a/TwitchChatSpeaker/Settings/TwitchSettingsContext.cs
+++ b/TwitchChatSpeaker/Settings/TwitchSettingsContext.cs
@@ -8,6 +8,6 @@ namespace Settings
 {
     public abstract class TwitchSettingsContext
     {
-        public const string SettingsFileName = "TwitchChatSpeaker.settings";
+        public const string SettingsFileName = "TwitchChatSpeaker.settings.json";
     }
 }

--- a/TwitchChatSpeaker/Settings/UserSettings.cs
+++ b/TwitchChatSpeaker/Settings/UserSettings.cs
@@ -1,217 +1,27 @@
-﻿using Logging.API;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Settings;
 
-namespace Settings
+public class UserSettings
 {
-    /// <summary>
-    /// A simple settings file implementation which can read and write JSON settings from a file
-    /// </summary>
-    public class UserSettings
+    public UserSettings()
     {
-        private readonly string settingsFilePath;
-        private readonly Dictionary<string, string> defaultSettings;
-        private readonly ILogger logger;
+        // Default configuration values go here
+        // The way this structures this is that we don't need to provide our own
+        // default in the main code, since it's already defined here and is overwritten
+        // when the config file is loaded by the ConfigHelper
 
-        private Dictionary<string, string> currentSettings;
-
-        /// <summary>
-        /// Ctor for creating a <see cref="UserSettings"/>
-        /// </summary>
-        /// <param name="settingsFilePath">The file path to store and read the settings from. Can be a partial path or a full path</param>
-        /// <param name="defaultSettings">The default settings to populate the file with in the event of a fatal event</param>
-        /// <param name="logger">An <see cref="ILogger"/> implementation to use for logging</param>
-        public UserSettings(string settingsFilePath, Dictionary<string, string> defaultSettings, ILogger logger)
-        {
-            this.settingsFilePath = settingsFilePath ?? throw new ArgumentNullException(nameof(settingsFilePath));
-            this.defaultSettings = defaultSettings ?? throw new ArgumentNullException(nameof(defaultSettings));
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            currentSettings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            if (File.Exists(settingsFilePath))
-            {
-                // Load the current settings
-                LoadSettings();
-            }
-            else
-            {
-                // Save the default settings
-                currentSettings = defaultSettings;
-                SaveSettings();
-            }
-        }
-
-        /// <summary>
-        /// Get the value of the setting with the given key, or the default value if the key is not present
-        /// </summary>
-        /// <param name="key">The key for the setting, not case sensitive</param>
-        /// <param name="defaultValue">The default value to return if the key isnt present</param>
-        /// <remarks>Sets the setting if it is not present</remarks>
-        public string GetSettingOrDefault(string key, string defaultValue)
-        {
-            if (currentSettings.ContainsKey(key))
-            {
-                return currentSettings[key];
-            }
-            else
-            {
-                SetOrCreateSetting(key, defaultValue);
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Gets an enum variation of the setting, or the default value if the key is not present
-        /// or the value is invalid
-        /// </summary>
-        public TEnum GetSettingOrDefault<TEnum>(string key, TEnum defaultValue)
-            where TEnum : struct
-        {
-            string rawValue = GetSettingOrDefault(key, defaultValue.ToString());
-            if (Enum.TryParse<TEnum>(rawValue, out TEnum parsedValue))
-            {
-                return parsedValue;
-            }
-            else
-            {
-                logger.Warning($"Unable to parse found setting for '{key}' into Enum, found value was '{rawValue}', using default of {defaultValue.ToString()} instead");
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Gets an enum variation of the setting, or the default value if the key is not present
-        /// or the value is invalid
-        /// </summary>
-        public Enum GetSettingOrDefault(string key, Enum defaultValue, Type enumType)
-        {
-            if (currentSettings.ContainsKey(key))
-            {
-                try
-                {
-                    return (Enum)Enum.Parse(enumType, currentSettings[key]);
-                }
-                catch (Exception e)
-                {
-                    return defaultValue;
-                }
-            }
-            else
-            {
-                SetOrCreateSetting(key, defaultValue.ToString());
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Gets a bool variation of the setting, or the default value if the key is not present
-        /// or the value is invalid
-        /// </summary>
-        public bool GetSettingOrDefault(string key, bool defaultValue)
-        {
-            string rawValue = GetSettingOrDefault(key, defaultValue.ToString());
-            if (bool.TryParse(rawValue, out bool parsedValue))
-            {
-                return parsedValue;
-            }
-            else
-            {
-                logger.Warning($"Unable to parse found setting for '{key}' into bool, found value was '{rawValue}', using default of {defaultValue.ToString()} instead");
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Gets an int variation of the setting, or the default value if the key is not present
-        /// or the value is invalid
-        /// </summary>
-        public int GetSettingOrDefault(string key, int defaultValue)
-        {
-            string rawValue = GetSettingOrDefault(key, defaultValue.ToString());
-            if (int.TryParse(rawValue, out int parsedValue))
-            {
-                return parsedValue;
-            }
-            else
-            {
-                logger.Warning($"Unable to parse found setting for '{key}' into int, found value was '{rawValue}', using default of {defaultValue.ToString()} instead");
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Gets a float variation of the setting, or the default value if the key is not present
-        /// or the value is invalid
-        /// </summary>
-        public float GetSettingOrDefault(string key, float defaultValue)
-        {
-            string rawValue = GetSettingOrDefault(key, defaultValue.ToString(CultureInfo.InvariantCulture));
-            if (float.TryParse(rawValue, NumberStyles.Any, CultureInfo.InvariantCulture, out float parsedValue))
-            {
-                return parsedValue;
-            }
-            else
-            {
-                logger.Warning($"Unable to parse found setting for '{key}' into float, found value was '{rawValue}', using default of {defaultValue.ToString()} instead");
-                return defaultValue;
-            }
-        }
-
-        /// <summary>
-        /// Sets the setting, creating it if it isn't already present
-        /// </summary>
-        /// <param name="key">The key for the setting, not case sensitive</param>
-        /// <param name="value">The value to use for the setting</param>
-        public void SetOrCreateSetting(string key, string value)
-        {
-            if (currentSettings.ContainsKey(key))
-            {
-                currentSettings[key] = value;
-            }
-            else
-            {
-                currentSettings.Add(key, value);
-            }
-            SaveSettings();
-        }
-
-        /// <summary>
-        /// Save the settings to the file
-        /// </summary>
-        private void SaveSettings()
-        {
-            try
-            {
-                string jsonString = JsonConvert.SerializeObject(currentSettings);
-                File.WriteAllText(settingsFilePath, jsonString);
-            }
-            catch (Exception e)
-            {
-                logger.Error($"Encountered Exception when saving settings: {e.ToString()}\nSettings have not been saved out!");
-            }
-        }
-
-        /// <summary>
-        /// Load the settings from the file
-        /// </summary>
-        private void LoadSettings()
-        {
-            try
-            {
-                string jsonString = File.ReadAllText(settingsFilePath);
-                currentSettings = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
-            }
-            catch (Exception e)
-            {
-                logger.Error($"Encountered Exception when loading settings: {e.ToString()}\nSetting them to the defaults instead");
-                currentSettings = defaultSettings;
-            }
-        }
+        TwitchOAuthKey = "";
+        TwitchChannelName = "";
+        MinimumEmojiLimit = 1;
+        EmojiPercentageLimit = 0;
+        FilteredWords = new List<string>();
+        PubliclyDeclareFilters = false;
     }
+    
+    // We actually define types here!
+    public string TwitchOAuthKey { get; set; }
+    public string TwitchChannelName { get; set; }
+    public int MinimumEmojiLimit { get; set; }
+    public int EmojiPercentageLimit { get; set; }
+    public List<string> FilteredWords { get; set; }
+    public bool PubliclyDeclareFilters { get; set; }
 }

--- a/TwitchChatSpeaker/Settings/UserSettings.cs
+++ b/TwitchChatSpeaker/Settings/UserSettings.cs
@@ -7,21 +7,31 @@ public class UserSettings
         // Default configuration values go here
         // The way this structures this is that we don't need to provide our own
         // default in the main code, since it's already defined here and is overwritten
-        // when the config file is loaded by the ConfigHelper
+        // when the config file is loaded by the FileHelper
 
         TwitchOAuthKey = "";
         TwitchChannelName = "";
-        MinimumEmojiLimit = 1;
+        TwitchChannelId = "";
+        MaxMessageLength = 80;
+        LimitEmojis = true;
+        MaximumEmojiLimit = 1;
         EmojiPercentageLimit = 0;
+        PrioritiseUniqueMessages = false;
+        AttemptsBeforeFailingUnique = 5;
+        FilterMessages = true;
         FilteredWords = new List<string>();
-        PubliclyDeclareFilters = false;
     }
     
     // We actually define types here!
     public string TwitchOAuthKey { get; set; }
     public string TwitchChannelName { get; set; }
-    public int MinimumEmojiLimit { get; set; }
-    public int EmojiPercentageLimit { get; set; }
+    public string TwitchChannelId { get; set; }
+    public int MaxMessageLength { get; set; }
+    public bool LimitEmojis { get; set; }
+    public int MaximumEmojiLimit { get; set; }
+    public double EmojiPercentageLimit { get; set; }
+    public bool PrioritiseUniqueMessages { get; set; }
+    public int AttemptsBeforeFailingUnique { get; set; }
+    public bool FilterMessages { get; set; }
     public List<string> FilteredWords { get; set; }
-    public bool PubliclyDeclareFilters { get; set; }
 }

--- a/TwitchChatSpeaker/TTSMessage.cs
+++ b/TwitchChatSpeaker/TTSMessage.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchChatSpeaker
+{
+    public class TTSMessage
+    {
+        public string Message;
+        public int EmojiCount;
+        public double? PercentageOfEmotes;
+
+        public TTSMessage(string message, int emojiCount, double? perEmojiCount)
+        {
+            Message = message;
+            EmojiCount = emojiCount;
+            PercentageOfEmotes = perEmojiCount;
+        }
+    }
+}

--- a/TwitchChatSpeaker/TwitchChatSpeaker.csproj
+++ b/TwitchChatSpeaker/TwitchChatSpeaker.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <Folder Include="Logging\" />
-    <Folder Include="Settings\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR implements several things, as well as changes a few things:
- Config file changed from `TwitchChatSpeaker.settings` to `TwitchChatSpeaker.settings.json` to better explain it's contents.
- Config loading now uses a class to store the type and name of config values, removing the string value limitation.
- README now contains explanation for config values.
- Added message filtering and the associated config values `FilterMessages` and `FilteredWords`. Saying a word on this filter prevents the message from being read out.
- Added emoji limiting and the associated config values `LimitEmojis`, `MaximumEmojiLimit`, and `EmojiPercentageLimit`. If a message contains less than or equal to `MaximumEmojiLimit` emojis, it sends without further checks, else the emoji names combined must take up less than `EmojiPercentageLimit` percent of the whole message for it to be read out.
- Added priority to unique messages and the associated config values `PrioritiseUniqueMessages` and `AttemptsBeforeFailingUnique`. If enabled, if a message is a duplicate of the last message read, it will ignore it up to `AttemptsBeforeFailingUnique` times in hopes that a unique message will be sent within those attempts. If no unique message is sent and all message attempts get a duplicate, the duplicate is sent as a failsafe.